### PR TITLE
More compat and TestSetExtensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  fast_finish: true
+  allow_failures:
+    - julia: nightly
 notifications:
   email: false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ os:
   - linux
   - osx
 julia:
-  # - release
   - 0.6
-  # - nightly
+  - nightly
 notifications:
   email: false
 script:

--- a/src/Syslogs.jl
+++ b/src/Syslogs.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Syslogs
 
 export Syslog

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+TestSetExtensions

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,13 +5,14 @@ import Compat.Libdl
 using Compat.Distributed
 using Compat: replace
 using Base: BufferStream
+using TestSetExtensions
 
 eval(Syslogs, Meta.parse("UDP_PORT = 8080"))
 eval(Syslogs, Meta.parse("TCP_PORT = 8080"))
 
 include("helpers.jl")
 
-@testset "Syslog" begin
+@testset ExtendedTestSet "Syslog" begin
     @testset "Local" begin
         info("Local Tests")
         io = Syslog()


### PR DESCRIPTION
Forcing precompile fixes the Memento issue, and tests pass on nightly so now seems like a decent time to enable them